### PR TITLE
(bug): Do not override labels on upgrade

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -385,7 +385,14 @@ func patchSveltosCluster(ctx context.Context, c client.Client, clusterNamespace,
 	}
 
 	logger.V(logs.LogDebug).Info("Updating SveltosCluster")
+	if currentSveltosCluster.Labels == nil {
+		currentSveltosCluster.Labels = map[string]string{}
+	}
+	for k := range labels {
+		currentSveltosCluster.Labels[k] = labels[k]
+	}
 	currentSveltosCluster.Labels = labels
+
 	currentSveltosCluster.Spec = libsveltosv1beta1.SveltosClusterSpec{
 		TokenRequestRenewalOption: &libsveltosv1beta1.TokenRequestRenewalOption{
 			RenewTokenRequestInterval: metav1.Duration{Duration: renewalInterval},


### PR DESCRIPTION
When Sveltos is upgraded, and the management cluster was already registered, current SveltosCluster labels must not be removed. SveltosCluster labels will be updated only if a label is specified as an arg of register-mgmt-cluster