### PR TITLE
Complete unqualified image names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ test: | check-manifests fmt vet ## Run uts.
 
 
 set-manifest-image:
-	sed -i'' -e 's@image: .*@image: '"${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./k8s/manifest.yaml >> ./k8s/manifest.yaml-e
+	sed -i'' -e 's@image: .*@image: '"docker.io/${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./k8s/manifest.yaml >> ./k8s/manifest.yaml-e
 	cp ./k8s/manifest.yaml ./manifest/manifest.yaml
 
 ##@ Build

--- a/k8s/manifest.yaml
+++ b/k8s/manifest.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: register-mgmt-cluster
-        image: projectsveltos/register-mgmt-cluster:main
+        image: docker.io/projectsveltos/register-mgmt-cluster:main
         imagePullPolicy: IfNotPresent
         args:
         - --labels=

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: register-mgmt-cluster
-        image: projectsveltos/register-mgmt-cluster:main
+        image: docker.io/projectsveltos/register-mgmt-cluster:main
         imagePullPolicy: IfNotPresent
         args:
         - --labels=


### PR DESCRIPTION
Add 'docker.io' registry server name where missing.

That allows applications to run on CRIs not configured to handle unqualified registries.