### PR TITLE
(feat) Make token indefinite

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,3 +44,16 @@ jobs:
       run: make create-cluster fv
       env:
         FV: true
+  FV_SA_SECRET:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Set up Go
+      uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+      with:
+        go-version: 1.23.4
+    - name: fv
+      run: make create-cluster-service-account-token-mode fv
+      env:
+        FV: true        

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,7 @@ manager_pull_policy.yaml-e
 manager_auth_proxy_patch.yaml-e
 k8s/manifest.yaml-e
 
+test/manifest.yaml
+test/patched_manifest.yaml
+
 version.txt

--- a/k8s/manifest.yaml
+++ b/k8s/manifest.yaml
@@ -37,6 +37,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - --labels=
+        - --service-account-token=false
         resources:
           requests:
             memory: 128Mi

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -37,6 +37,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - --labels=
+        - --service-account-token=false
         resources:
           requests:
             memory: 128Mi


### PR DESCRIPTION
When registering the management cluster, register-mgmt-cluster can be passed this arg: `service-account-token=true`

When that is set, register-mgmt-cluster creates a Secret of type `kubernetes.io/service-account-token`
Instead of generating a token with an expiration, the token is taken from the newly created Secret.

Fixes #92 